### PR TITLE
feat: introduce data layer scaffolding

### DIFF
--- a/scripts/event_queue.gd
+++ b/scripts/event_queue.gd
@@ -1,0 +1,17 @@
+extends RefCounted
+class_name EventQueue
+
+var events: Array = []
+
+func push_replace(cell: Vector2i, to_tile: int, reason: StringName = &"") -> void:
+    events.append({
+        "type": "replace_tile",
+        "cell": cell,
+        "to": to_tile,
+        "reason": reason,
+    })
+
+func pop_all() -> Array:
+    var out := events
+    events = []
+    return out

--- a/scripts/event_queue.gd.uid
+++ b/scripts/event_queue.gd.uid
@@ -1,0 +1,1 @@
+uid://x2lyjzq4po0rw

--- a/scripts/material_db.gd
+++ b/scripts/material_db.gd
@@ -1,0 +1,4 @@
+extends Resource
+class_name MaterialDB
+
+@export var materials: Dictionary = {}

--- a/scripts/material_db.gd.uid
+++ b/scripts/material_db.gd.uid
@@ -1,0 +1,1 @@
+uid://6ywu23podjj95

--- a/scripts/tile_change.gd
+++ b/scripts/tile_change.gd
@@ -9,10 +9,9 @@ signal cells_changed() # 필요 시 AABB/리스트로 확장
 @export_node_path("Node") var terrain_node_path: NodePath # Terrain 노드
 var _terrain: Terrain
 
-# 내부 상태
+var _store: TileStore
+var _queue: EventQueue
 var size: Vector2i
-var _tiles: PackedInt32Array = PackedInt32Array() # 권한 보유: 현재 월드의 tile_types
-var _ops: Array = [] # [{cell:Vector2i, to:int, reason:StringName}]
 
 # 타일 ID (월드와 일치해야 함)
 const TILE_AIR: int = 0
@@ -24,55 +23,45 @@ func _ready() -> void:
 	if terrain_node_path != NodePath():
 		_terrain = get_node(terrain_node_path) as Terrain
 
-func setup(initial_tiles: PackedInt32Array, grid_size: Vector2i) -> void:
-	size = grid_size
-	_tiles = PackedInt32Array(initial_tiles) # 사본 보관
-	_ops.clear()
+func setup(store: TileStore, grid_size: Vector2i, queue: EventQueue) -> void:
+        _store = store
+        _queue = queue
+        size = grid_size
 
 func get_tiles() -> PackedInt32Array:
-	return _tiles
+        if _store:
+                return _store.get_tiles()
+        return PackedInt32Array()
 
 func queue_replace(cell: Vector2i, to_tile: int, reason: StringName = &"") -> void:
-	if size == Vector2i.ZERO:
-		push_warning("[TileChange] setup() not called yet."); return
-	if cell.x < 0 or cell.y < 0 or cell.x >= size.x or cell.y >= size.y:
-		return
-	_ops.append({ "cell": cell, "to": to_tile, "reason": reason })
+        if size == Vector2i.ZERO or _queue == null:
+                push_warning("[TileChange] setup() not ready."); return
+        if cell.x < 0 or cell.y < 0 or cell.x >= size.x or cell.y >= size.y:
+                return
+        _queue.push_replace(cell, to_tile, reason)
 
 func queue_destroy(cell: Vector2i, reason: StringName = &"destroy") -> void:
-	queue_replace(cell, TILE_AIR, reason)
+        queue_replace(cell, TILE_AIR, reason)
 
-func commit() -> void:
-	if _ops.is_empty():
-		return
-	var changed: bool = false
-
-	for op in _ops:
-		var cell: Vector2i = op["cell"]
-		var to_tile: int = int(op["to"])
-		var reason: StringName = op["reason"]
-
-		var idx: int = cell.y * size.x + cell.x
-		if idx < 0 or idx >= _tiles.size():
-			continue
-
-		var from_tile: int = _tiles[idx]
-		if from_tile == to_tile:
-			continue
-
-		# 내부 상태 갱신
-		_tiles[idx] = to_tile
-		changed = true
-
-		# Terrain 반영(부분 업데이트)
-		if _terrain != null:
-			_terrain.apply_cell_change(cell, to_tile)
-
-		# 이벤트 브로드캐스트
-		if to_tile == TILE_AIR:
-			emit_signal("tile_destroyed", cell, from_tile, reason)
-		emit_signal("tile_replaced", cell, from_tile, to_tile, reason)
-
-	_ops.clear()
-	if changed:
-		emit_signal("cells_changed")
+func apply_events(events: Array) -> void:
+        if _store == null:
+                return
+        var changed: bool = false
+        for op in events:
+                if op.get("type") != "replace_tile":
+                        continue
+                var cell: Vector2i = op.get("cell", Vector2i.ZERO)
+                var to_tile: int = int(op.get("to", TILE_AIR))
+                var reason: StringName = op.get("reason", &"")
+                var from_tile: int = _store.get_tile(cell)
+                if from_tile == to_tile:
+                        continue
+                _store.set_tile(cell, to_tile)
+                changed = true
+                if _terrain != null:
+                        _terrain.apply_cell_change(cell, to_tile)
+                if to_tile == TILE_AIR:
+                        emit_signal("tile_destroyed", cell, from_tile, reason)
+                emit_signal("tile_replaced", cell, from_tile, to_tile, reason)
+        if changed:
+                emit_signal("cells_changed")

--- a/scripts/tile_store.gd
+++ b/scripts/tile_store.gd
@@ -1,0 +1,27 @@
+extends Resource
+class_name TileStore
+
+var size: Vector2i = Vector2i.ZERO
+var tiles: PackedInt32Array = PackedInt32Array()
+
+func setup(initial_tiles: PackedInt32Array, grid_size: Vector2i) -> void:
+    size = grid_size
+    tiles = PackedInt32Array(initial_tiles)
+
+func _index(cell: Vector2i) -> int:
+    return cell.y * size.x + cell.x
+
+func get_tile(cell: Vector2i) -> int:
+    var idx: int = _index(cell)
+    if idx < 0 or idx >= tiles.size():
+        return 0
+    return tiles[idx]
+
+func set_tile(cell: Vector2i, tile_id: int) -> void:
+    var idx: int = _index(cell)
+    if idx < 0 or idx >= tiles.size():
+        return
+    tiles[idx] = tile_id
+
+func get_tiles() -> PackedInt32Array:
+    return tiles

--- a/scripts/tile_store.gd.uid
+++ b/scripts/tile_store.gd.uid
@@ -1,0 +1,1 @@
+uid://yps7vx35vzvo3

--- a/scripts/world.gd
+++ b/scripts/world.gd
@@ -22,9 +22,13 @@ var current_overlay: int = OverlayMode.NONE
 
 # 오버레이 경로 테이블 (존재하는 것만 등록)
 var overlay_paths := {
-	OverlayMode.HEATMAP:     NodePath("OverlaysLayer/HeatmapOverlay"),
-	OverlayMode.HEAT_SOURCE: NodePath("OverlaysLayer/HeatSourceOverlay"),
+        OverlayMode.HEATMAP:     NodePath("OverlaysLayer/HeatmapOverlay"),
+        OverlayMode.HEAT_SOURCE: NodePath("OverlaysLayer/HeatSourceOverlay"),
 }
+
+var tile_store: TileStore = TileStore.new()
+var event_queue: EventQueue = EventQueue.new()
+var material_db: MaterialDB = MaterialDB.new()
 
 func _ready() -> void:
 	if worldgen == null:
@@ -52,7 +56,8 @@ func _ready() -> void:
 		durability.break_requested.connect(crack_overlay.on_break_requested)
 
 func _on_world_generated(tiles: PackedInt32Array, size: Vector2i, liquid_amount: PackedFloat32Array, springs: PackedVector2Array) -> void:
-	terrain.apply_tiles(tiles, size)
+        terrain.apply_tiles(tiles, size)
+        tile_store.setup(tiles, size)
 	# center camera on the map
 	if has_node("Camera2D") and terrain.ground != null and terrain.ground.tile_set != null:
 		var ts: TileSet = terrain.ground.tile_set
@@ -75,8 +80,8 @@ func _on_world_generated(tiles: PackedInt32Array, size: Vector2i, liquid_amount:
 	if durability:
 		durability.setup_from_tiles(tiles, size)
 
-	if tchange:
-		tchange.setup(tiles, size) # 타일 변경 시스템에 현재 맵 전달
+        if tchange:
+                tchange.setup(tile_store, size, event_queue) # 타일 변경 시스템에 현재 맵 전달
 	if liquid:
 		var solid := PackedByteArray()
 		if temp:
@@ -103,8 +108,10 @@ func _on_tick_sim(dt: float) -> void:
 		liquid.tick_liquid(dt)
 		if liquid_overlay != null:
 			liquid_overlay.render(liquid.get_amounts())
-	if tchange:
-		tchange.commit() # 큐에 쌓인 변경을 일괄 적용
+        if tchange:
+                var events := event_queue.pop_all()
+                if events.size() > 0:
+                        tchange.apply_events(events)
 
 func _on_tile_destroyed(cell: Vector2i, from_tile: int, reason: StringName) -> void:
 	if temp != null:


### PR DESCRIPTION
## Summary
- add TileStore, EventQueue, and MaterialDB classes
- route TileChange through TileStore and event queue
- World manages data layer and applies queued events

## Testing
- `godot --headless --quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3018bbe4c832592cd7f785ecd7084